### PR TITLE
Short PIN crash

### DIFF
--- a/Source/src_android/PinCheckerLibrary/src/main/java/com/wultra/android/passphrasemeter/PasswordTester.java
+++ b/Source/src_android/PinCheckerLibrary/src/main/java/com/wultra/android/passphrasemeter/PasswordTester.java
@@ -120,7 +120,7 @@ public class PasswordTester {
      * @param pin PIN to scan.
      * @return Immutable set of issues.
      * @throws WrongPinException if provided PIN contains some invalid characters,
-     * or is too long (there's a hard limit of 100 characters).
+     * is too short or long (minimum length for PIN is 4 and maximum 100).
      */
     public Set<PinTestResult> testPin(@NonNull String pin) throws WrongPinException {
 

--- a/Source/src_android/gradle.properties
+++ b/Source/src_android/gradle.properties
@@ -1,2 +1,2 @@
-VERSION_NAME=1.0.0
+VERSION_NAME=1.0.1
 GROUP_ID=com.wultra.android.passphrasemeter

--- a/Source/src_ios/PasswordTester.swift
+++ b/Source/src_ios/PasswordTester.swift
@@ -53,8 +53,10 @@ public class PasswordTester {
     
     /// Tests strength of the PIN.
     ///
-    /// - Parameter pin: PIN to evaluate. This needs to be digits only.
-    /// - Returns: Optionset of found issues.
+    /// Minimum length for PIN is 4 and maximum 100.
+    ///
+    /// - Parameter pin: PIN to evaluate..
+    /// - Returns: OptionSet of found issues.
     public func testPin(_ pin: String) -> PinTestResult {
 		
         let code = WPM_testPasscode(pin).rawValue

--- a/Source/src_native/jni/PasswordTester.cpp
+++ b/Source/src_native/jni/PasswordTester.cpp
@@ -77,7 +77,7 @@ JNIEXPORT jint JNICALL Java_com_wultra_android_passphrasemeter_PasswordTester_te
         result = WPM_testPasscode(cppPin);
         jenv->ReleaseStringUTFChars(pin, cppPin);
     } else {
-        result = WPM_PasswordResult_WrongInput;
+        result = WPM_PasscodeResult_WrongInput;
     }
     return result;
 }

--- a/Source/src_native/pin_tester.c
+++ b/Source/src_native/pin_tester.c
@@ -27,6 +27,11 @@
  */
 #define MAX_PIN_LENGTH 100
 
+/**
+ Minimum PIN length to be able to get reasonable result.
+ */
+#define MIN_PIN_LENGTH 4
+
 static const char* mostUsedPin[] =
 {
     "1234","1111","0000","1212","7777","1004","2000","4444","2222","6969","9999","3333","5555","6666","1122","1313","8888",
@@ -387,14 +392,14 @@ static bool isFrequentlyUsed(const char *pin)
 }
 
 /**
- Validates input string whether contains only digits.
+ Validates input string whether contains only digits and is within the "string size limit".
 
  @param pin string with PIN
  @param pinLength length of provided PIN
  @return true if PIN is not valid.
  */
 static bool isInvalidPIN(const char * pin, size_t pinLength) {
-	if (pinLength > MAX_PIN_LENGTH) {
+	if (pinLength > MAX_PIN_LENGTH || pinLength < MIN_PIN_LENGTH) {
 		return true;
 	}
     for (size_t index = 0; index < pinLength; index++) {

--- a/Source/src_native/wultra_pass_meter.c
+++ b/Source/src_native/wultra_pass_meter.c
@@ -39,7 +39,7 @@ WPM_PasswordResult WPM_testPassword(const char *password)
     if (log < 6) return WPM_PasswordResult_Weak;
     if (log < 8) return WPM_PasswordResult_Moderate;
     if (log < 10) return WPM_PasswordResult_Good;
-    return  WPM_PasswordResult_Strong;
+    return WPM_PasswordResult_Strong;
 }
 
 /**

--- a/WultraPassphraseMeter.podspec
+++ b/WultraPassphraseMeter.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'WultraPassphraseMeter'
-  s.version          = '1.0.0'
+  s.version          = '1.0.1'
   s.summary          = 'Streng tester for passwords and passcodes.'
   s.description      = 'A library that checks the strength of a pin or a password.'
   s.social_media_url = 'https://twitter.com/wultra'

--- a/docs/Platform-Android.md
+++ b/docs/Platform-Android.md
@@ -4,7 +4,7 @@
 
 To get Wultra Passphrase Meter for Android up and running in your app, add following dependency in your `gradle.build` file:
 
-```gradle
+```groovy
 repositories {
     jcenter() // if not defined elsewhere...
 }


### PR DESCRIPTION
Addressing #21 

Minimal length for PIN check is now 4 as most checks don't make sense for PINs shorter than 4.