### PR TITLE
SPM build fix

### DIFF
--- a/Source/proj_ios/WultraPassphraseMeter.xcodeproj/project.pbxproj
+++ b/Source/proj_ios/WultraPassphraseMeter.xcodeproj/project.pbxproj
@@ -554,7 +554,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_SWIFT_FLAGS = "-Xfrontend -no-serialize-debugging-options";
+				OTHER_SWIFT_FLAGS = "$(inherited) -Xfrontend -no-serialize-debugging-options";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -615,7 +615,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
-				OTHER_SWIFT_FLAGS = "-Xfrontend -no-serialize-debugging-options";
+				OTHER_SWIFT_FLAGS = "$(inherited) -Xfrontend -no-serialize-debugging-options";
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";

--- a/Source/proj_ios/WultraPassphraseMeter.xcodeproj/project.pbxproj
+++ b/Source/proj_ios/WultraPassphraseMeter.xcodeproj/project.pbxproj
@@ -554,6 +554,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_SWIFT_FLAGS = "-Xfrontend -no-serialize-debugging-options";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -614,6 +615,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
+				OTHER_SWIFT_FLAGS = "-Xfrontend -no-serialize-debugging-options";
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -76,7 +76,8 @@ function BUILD_LIB
         -configuration "Release" \
         -sdk iphoneos \
         SKIP_INSTALL=NO \
-        SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO
+        SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO \
+        BUILD_LIBRARY_FOR_DISTRIBUTION=YES
 
     # build for ios simulator
     xcodebuild archive \
@@ -86,7 +87,8 @@ function BUILD_LIB
         -configuration "Release" \
         -sdk iphonesimulator \
         SKIP_INSTALL=NO \
-        SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO
+        SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO \
+        BUILD_LIBRARY_FOR_DISTRIBUTION=YES
 
     # create xcframwork
     xcodebuild -create-xcframework \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -75,7 +75,8 @@ function BUILD_LIB
         -archivePath "${ios_archive}" \
         -configuration "Release" \
         -sdk iphoneos \
-        SKIP_INSTALL=NO
+        SKIP_INSTALL=NO \
+        SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO
 
     # build for ios simulator
     xcodebuild archive \
@@ -84,7 +85,8 @@ function BUILD_LIB
         -archivePath "${sim_archive}" \
         -configuration "Release" \
         -sdk iphonesimulator \
-        SKIP_INSTALL=NO
+        SKIP_INSTALL=NO \
+        SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO
 
     # create xcframwork
     xcodebuild -create-xcframework \


### PR DESCRIPTION
Added build parameter to exclude serialized debugging options.

If this is not included, some debugging functions (for the whole project which imports this library) do not work.