### PR TITLE
Fix #46: Use specific NDK version

### DIFF
--- a/Source/src_android/PinCheckerLibrary/build.gradle.kts
+++ b/Source/src_android/PinCheckerLibrary/build.gradle.kts
@@ -22,6 +22,7 @@ plugins {
 android {
 
     compileSdk = Constants.compileSdkVersion
+    ndkVersion = Constants.ndkVersion
 
     defaultConfig {
         minSdk = Constants.minSdkVersion

--- a/Source/src_android/buildSrc/src/main/kotlin/Constants.kt
+++ b/Source/src_android/buildSrc/src/main/kotlin/Constants.kt
@@ -14,4 +14,5 @@ object Constants {
     const val minSdkVersion = 19
     const val targetSdkVersion = 32
     const val compileSdkVersion = 32
+    const val ndkVersion = "25.1.8937393"  // r25b
 }

--- a/Source/src_android/settings.gradle
+++ b/Source/src_android/settings.gradle
@@ -1,3 +1,5 @@
+rootProject.name = "PassphraseMeter"
+
 include ':PinCheckerLibrary'
 include ':PinCheckerDictionary'
 include ':PinCheckerDictionaryCzsk'


### PR DESCRIPTION
This PR sets specific NDK version to build the library. It also changes name of the root project to "PassphraseMeter". This is is useful for list of recent projects in Android Studio, so there's no longer "src_android" in the recent projects list.