### PR TITLE
Fix #47: Low level API documentation

### DIFF
--- a/Source/src_ios/PasswordTester.swift
+++ b/Source/src_ios/PasswordTester.swift
@@ -120,7 +120,7 @@ public struct PasswordTesterDictionary {
 /// Result of the PIN testing.
 public struct PinTestResult {
     
-    /// Tested pin
+    /// Length of PIN
     public let pinLength: Int
     
     /// Issues found
@@ -148,6 +148,15 @@ public struct PinTestResult {
         } else {
             return issues.contains(.frequentlyUsed) || issues.contains(.notUnique) || issues.contains(.repeatingCharacters) || issues.contains(.patternFound)
         }
+    }
+    
+    /// Construct structure from provided parameters.
+    /// - Parameters:
+    ///   - pinLength: Length of PIN
+    ///   - issues: Issues found.
+    public init(pinLength: Int, issues: PinTestIssue) {
+        self.pinLength = pinLength
+        self.issues = issues
     }
 }
 

--- a/docs/Platform-Android.md
+++ b/docs/Platform-Android.md
@@ -114,6 +114,32 @@ If everything works fine, then you can test your passwords in the simulator (or 
 
 ![Android Example App](./images/android-tester.png)
 
+### Integration with secure password objects
+
+If your application is using a custom objects, such as `Password` from [PowerAuth mobile SDK](https://github.com/wultra/powerauth-mobile-sdk) for keeping user's password securely in the memory, then you can easily test PIN or password without a leaking plaintext password in the memory. This is due to fact, that library provide variants of `testPin()` and `testPassword()` functions with byte array at input. It's expected that you provide UTF8 encoded string to both functions to work correctly.
+
+```kotlin
+import io.getlime.security.powerauth.core.Password
+
+fun Password.testPin() : PinTestResult {
+    var result = PinTestResult(0, emptySet())
+    validatePasswordComplexity { 
+        result = PasswordTester.getInstance().testPin(it)
+        0
+    }
+    return result
+}
+
+fun Password.testPassword(): PasswordStrength {
+    var result = PasswordStrength.VERY_WEAK
+    validatePasswordComplexity { 
+        result = PasswordTester.getInstance().testPassword(it)
+        0
+    }
+    return result
+}
+```
+
 ## Contact
 
 If you need any assistance, do not hesitate to drop us a line at [hello@wultra.com](mailto:hello@wultra.com) or our official [gitter.im/wultra](https://gitter.im/wultra) channel.

--- a/docs/Platform-iOS.md
+++ b/docs/Platform-iOS.md
@@ -169,6 +169,35 @@ If everything works fine, then you can test your passwords in the simulator (or 
 
 ![iOS Example App](./images/ios-tester.png)
 
+### Integration with secure password objects
+
+If your application is using a custom objects, such as `PowerAuthCorePassword` from [PowerAuth mobile SDK](https://github.com/wultra/powerauth-mobile-sdk) for keeping user's password securely in the memory, then you can easily test PIN or password without a leaking plaintext password in the memory. This is due to fact, that both `testPin()` and `testPassword()` functions accept `UnsafePointer<Int8>` at input. It's expected that you provide nul-terminated UTF8 encoded string to both functions to work correctly. If you provide a regular swift's string, then this is achieved by implicit conversion to such array of bytes by swift compiler.
+
+The following example shows how to ingegrate this library with `PowerAuthCorePassword` object:
+```swift
+import PowerAuthCore
+
+extension PowerAuthCorePassword {
+    func testPin() -> PinTestResult {
+        var result = PinTestResult(pinLength: 0, issues: .pinFormatError)
+        _ = validateComplexity { ptr, _ in
+            result = PasswordTester.shared.testPin(ptr)
+            return 0
+        }
+        return result
+    }
+    
+    func testPassword() -> PasswordStrength {
+        var result = PasswordStrength.veryWeak
+        _ = validateComplexity { ptr, _ in
+            result = PasswordTester.shared.testPassword(ptr)
+            return 0
+        }
+        return result
+    }
+}
+```
+
 ## Contact
 
 If you need any assistance, do not hesitate to drop us a line at [hello@wultra.com](mailto:hello@wultra.com) or our official [gitter.im/wultra](https://gitter.im/wultra) channel.


### PR DESCRIPTION
This PR documenting low level API functions for testing password & PIN. I had to make `PinTestResult` structure constructor on iOS available from outside of the library. Otherwise it will be impossible to integrate library with 3rd party projects.