### PR TITLE
Fixed month-date variant in isDateOK() function

### DIFF
--- a/Source/src_native/pin_tester.c
+++ b/Source/src_native/pin_tester.c
@@ -346,7 +346,7 @@ static bool isDateOK(const char *pin, const size_t pinLength) {
         struct tm r;
         
         // If the PIN could be date like 0304 (3rd of April or 4th of March)
-        if (parseDate("%d%m", pin, &r) || parseDate("%d%m", pin, &r)) {
+        if (parseDate("%d%m", pin, &r) || parseDate("%m%d", pin, &r)) {
             return false;
         }
         


### PR DESCRIPTION
This PR fixes bug in `isDateOK()` PIN testing function and now it tests both `MMDD` and `DDMM` variants of date.