### PR TITLE
Fix #50: New isDateOK implementation

### DIFF
--- a/Source/examples/Android/PassMeterExample/app/src/androidTest/java/com/wultra/passmeterexample/PassMeterInstrumentedTest.kt
+++ b/Source/examples/Android/PassMeterExample/app/src/androidTest/java/com/wultra/passmeterexample/PassMeterInstrumentedTest.kt
@@ -52,8 +52,8 @@ class PassMeterInstrumentedTest {
 
     @Test
     fun testPinDates() {
-        val dates = arrayOf("0304", "1012", "0101", "1998", "2005", "150990", "241065", "16021998", "03122001")
-        val noDates = arrayOf("1313", "0028", "1287", "9752", "151590", "001297", "41121987")
+        val dates = arrayOf("0304", "1012", "0101", "1998", "2005", "150990", "241065", "16021998", "03122001", "2901", "2802")
+        val noDates = arrayOf("1313", "0028", "1287", "9752", "151590", "001297", "41121987", "3002", "3102")
 
         for (date in dates) {
             assertTrue(date, PasswordTester.getInstance().testPin(date.toByteArray()).issues.contains(PinTestIssue.POSSIBLY_DATE))

--- a/Source/examples/iOS/PassMeterExample/PassMeterExampleTests/PassMeterExampleTests.swift
+++ b/Source/examples/iOS/PassMeterExample/PassMeterExampleTests/PassMeterExampleTests.swift
@@ -60,8 +60,8 @@ class PassMeterExampleTests: XCTestCase {
     }
     
     func testPinDates() {
-        let dates = ["0304", "1012", "3101", "1998", "2005", "150990", "241065", "16021998", "03122001"]
-        let noDates = ["1313", "0028", "1287", "9752", "151590", "001297", "41121987"]
+        let dates = ["0304", "1012", "3101", "1998", "2005", "150990", "241065", "16021998", "03122001", "2901", "2802"]
+        let noDates = ["1313", "0028", "1287", "9752", "151590", "001297", "41121987", "3002", "3102"]
         
         for date in dates {
             XCTAssert(PasswordTester.shared.testPin(date).issues.contains(.possiblyDate), date)

--- a/Source/src_native/pin_tester.c
+++ b/Source/src_native/pin_tester.c
@@ -131,7 +131,7 @@ int parseInt(const char * date, int size)
 {
     int value = 0;
     while (*date && size-- > 0) {
-        if (!isnumber(*date)) {
+        if (!isdigit(*date)) {
             break;
         }
         int digit = *date++ - '0';

--- a/Source/tests/PassMeterTester/PassMeterTester/PinGenerator.swift
+++ b/Source/tests/PassMeterTester/PassMeterTester/PinGenerator.swift
@@ -28,12 +28,12 @@ final class PinGenerator {
         
         var started = true
         
-        pins(maxLength: testingPinLength) { pin, percent in
+        pins(maxLength: testingPinLength) { pin, _ in
             
             //print(String(format: "%.2f%% evaluated \(pin)", percent*100))
             
             if pin.result.isEmpty == false {
-                h.write("\(started ? "" : ",")\(pin.fileValue)".data(using: .utf8)!)
+                h.write("\(started ? "" : "\n")\(pin.fileValue)".data(using: .utf8)!)
             }
             
             if started {
@@ -51,24 +51,24 @@ final class PinGenerator {
         // we only need to test 20% of the numbers to get the full coverage of variants (the rest is just variants for 1234....,2345....,3456....)
         let capacity = Int(pow(10, Double(maxLength)))/5
         var tested = 0.0
-        let total = Double(capacity)
+        let total = 1.0/Double(capacity)
         
         for pin in 0..<capacity {
             
             tested += 1
             
             if tested.truncatingRemainder(dividingBy: 100000) == 0 {
-                print("  \(((tested/total)*100).rounded(toPlaces: 2))% done \r", terminator: "")
+                print("  \(((tested*total)*100).rounded(toPlaces: 2))% done \r", terminator: "")
                 fflush(stdout)
             }
             
             let digits = numberOfDigits(in: pin)
             for length in 4...maxLength {
-                if digits > length {
+            if digits > length {
                     continue
                 }
                 let formatted =  String(format: "%0\(length)d", pin)
-                handle(Pin(value: formatted, result: PasswordTester.shared.testPin(formatted).issues), Double(pin)/Double(capacity))
+                handle(Pin(value: formatted, result: PasswordTester.shared.testPin(formatted).issues), Double(pin)*total)
             }
         }
     }

--- a/Source/tests/PassMeterTester/PassMeterTester/PinTester.swift
+++ b/Source/tests/PassMeterTester/PassMeterTester/PinTester.swift
@@ -28,7 +28,7 @@ final class PinTester {
         
         var badPins = 0
         
-        PinGenerator.pins(maxLength: testingPinLength) { pin, percent in
+        PinGenerator.pins(maxLength: testingPinLength) { pin, _ in
             
             if let filePin = loadedPins.removeValue(forKey: pin.value) {
                 if pin.result != filePin.result {
@@ -66,7 +66,7 @@ final class PinTester {
             return nil
         }
         
-        let items = content.split(separator: ",").map { Pin(fromFileFormat: String($0)) }
+        let items = content.split(separator: "\n").map { Pin(fromFileFormat: String($0)) }
         
         return Dictionary(uniqueKeysWithValues: items.map({ ($0.value, $0) }))
     }


### PR DESCRIPTION
This PR changes `isDateOK()` implementation in native pin tester library. The new implementation doesn't produce false positive warnings for invalid dates (for example `3102`). The code is 100% equal to implementation used in our PowerAuth mobile SDK for React Native. This is because I discovered the issue while I was working on PIN validation feature embedded in our RN wrapper.